### PR TITLE
Use home assistant time component

### DIFF
--- a/esphome/ble-node.h
+++ b/esphome/ble-node.h
@@ -39,7 +39,7 @@ class BleNodeComponent : public Component, public CustomMQTTDevice {
         if (!getLocalTime(&timeinfo)) {
             return(0);
         }
-        time(&now);
+        ::time(&now);
         return now;
     }
 

--- a/esphome/esphome_node_template
+++ b/esphome/esphome_node_template
@@ -34,5 +34,9 @@ custom_component:
 - lambda: |-
     auto my_node = new BleNodeComponent("room_name"); # TODO replace rooom_name with your room name
     return {my_node};
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time
 # END OF SECTION 2
     

--- a/esphome/esphome_node_template
+++ b/esphome/esphome_node_template
@@ -34,9 +34,17 @@ custom_component:
 - lambda: |-
     auto my_node = new BleNodeComponent("room_name"); # TODO replace rooom_name with your room name
     return {my_node};
+# END OF SECTION 2
 
+# CHECK THIS - SECTION 3
+
+# Some devices may not have a working time service.  This can lead to
+# updates being dropped with "Skipping message with old timestamp" in the logs.
+#
+# The homeassistant_time service as it is the esphome recommended
+# default time service, enable like this:
 time:
   - platform: homeassistant
     id: homeassistant_time
-# END OF SECTION 2
-    
+
+# END OF SECTION 3


### PR DESCRIPTION
Using the default template and instructions I had no timestamps being generated.

I first tried the `sntp` time platform but this did not resolve the problem.  Switching to the  `homeassistant_time` platform worked.

However both platforms caused a compile error which can be resolved by selecting `time()` from the global namespace explicitly.

```
In file included from src/main.cpp:28:
src/ble-node.h: In member function 'long unsigned int BleNodeComponent::getTime()':
src/ble-node.h:42:9: error: reference to 'time' is ambiguous
         time(&now);
         ^~~~
In file included from src/esphome/components/homeassistant/time/homeassistant_time.h:4,
                 from src/esphome.h:21,
                 from src/main.cpp:3:
src/esphome/components/time/real_time_clock.h:11:11: note: candidates are: 'namespace esphome::time { }'
 namespace time {
           ^~~~
In file included from /data/cache/platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/include/newlib/platform_include/time.h:22,
                 from /data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/sys-include/sys/time.h:414,
                 from /data/cache/platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/include/newlib/platform_include/sys/time.h:16,
                 from /data/cache/platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/include/newlib/platform_include/pthread.h:18,
                 from /data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/xtensa-esp32-elf/no-rtti/bits/gthr-default.h:48,
                 from /data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/xtensa-esp32-elf/no-rtti/bits/gthr.h:151,
                 from /data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/ext/atomicity.h:35,
                 from /data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/bits/basic_string.h:39,
                 from /data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/string:52,
                 from /data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/stdexcept:39,
                 from /data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/include/c++/8.4.0/array:39,
                 from src/esphome/components/api/api_noise_context.h:3,
                 from src/esphome/components/api/api_frame_helper.h:13,
                 from src/esphome/components/api/api_connection.h:3,
                 from src/esphome.h:3,
                 from src/main.cpp:3:
/data/cache/platformio/packages/toolchain-xtensa-esp32/xtensa-esp32-elf/sys-include/time.h:59:11: note:                 'time_t time(time_t*)'
 time_t    time (time_t *_timer);
           ^~~~
*** [.pioenvs/esp1/src/main.cpp.o] Error 1
```