### PR TITLE
Rework "header, library and lambda" into "esphome component"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Install esphome
         run: pip install -r test/requirements-dev.txt
 
+      - uses: actions/cache@v3
+        id: esphome-cache # use this to check for `cache-hit` ==> if: steps.esphome-cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            test/.esphome/**
+            $HOME/.platformio/**
+          key: ${{ matrix.os }}-${{matrix.python}}-esphome
+
       - name: Check config
         run: esphome config test/*.yml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Test build
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: ${{matrix.python}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest]
+        python:
+          - 3.12
+
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{matrix.python}}
+          cache: 'pip' # caching pip dependencies
+          cache-dependency-path: '**/requirements-dev.txt'
+
+      - name: Install esphome
+        run: pip install -r test/requirements-dev.txt
+
+      - name: Check config
+        run: esphome config test/*.yml
+
+      - name: Build
+        run: esphome compile test/*.yml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .vscode/ipch
 .vscode/extensions.json
 .vscode/settings.json
+
+.esphome/
+__pycache__/

--- a/components/esp32_ble_presense/__init__.py
+++ b/components/esp32_ble_presense/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# (C) Copyright 2024 - Greg Whiteley
+
+import esphome.config_validation as cv
+import esphome.codegen as cg
+
+from esphome.const import (
+    CONF_ID,
+    CONF_AREA,
+)
+
+CODEOWNERS = ["@formatBCE"]
+
+ESP32_BLE_Presense_ns = cg.esphome_ns.namespace("ESP32_BLE_Presense")
+ESP32_BLE_Presense = ESP32_BLE_Presense_ns.class_(
+    "ESP32_BLE_Presense",
+    cg.PollingComponent,
+    cg.esphome_ns.namespace("mqtt").class_("CustomMQTTDevice"))
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(ESP32_BLE_Presense),
+    cv.Required(CONF_AREA): cv.string,
+}).extend(cv.COMPONENT_SCHEMA)
+
+async def to_code(config):
+    cg.add_library(
+        name="NimBLE-Arduino",
+        version="1.4.2",
+    )
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    cg.add(var.set_area(config[CONF_AREA]))

--- a/components/esp32_ble_presense/esp32_ble_presense.cpp
+++ b/components/esp32_ble_presense/esp32_ble_presense.cpp
@@ -1,0 +1,139 @@
+////////////////////////////////////////////////////////////////////////
+// SPDX-License-Identifier: AGPL-3.0-only
+// (C) Copyright 2022-2024 - formatBCE
+
+#include "esp32_ble_presense.h"
+
+#include "esphome/core/log.h"
+
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+
+#define bleScanInterval 0x80 // Used to determine antenna sharing between Bluetooth and WiFi. Do not modify unless you are confident you know what you're doing
+#define bleScanWindow 0x40 // Used to determine antenna sharing between Bluetooth and WiFi. Do not modify unless you are confident you know what you're doing
+
+using namespace esphome;
+
+namespace ESP32_BLE_Presense {
+
+NimBLEScan* pBLEScan;
+
+class BleAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
+
+    ESP32_BLE_Presense& parent_;
+
+public:
+    BleAdvertisedDeviceCallbacks(ESP32_BLE_Presense& parent) : parent_(parent) {}
+
+    void onResult(NimBLEAdvertisedDevice* device) {
+        if (!device)
+            return;
+
+        parent_.reportDevice(device->getAddress().toString(),
+                             device->getRSSI(),
+                             device->getManufacturerData());
+    }
+};
+
+// Copies unneccessarily
+static std::string capitalizeString(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c){ return std::toupper(c); });
+    return s;
+}
+
+static unsigned long getTime() {
+    time_t now;
+    struct tm timeinfo;
+    if (!getLocalTime(&timeinfo)) {
+        return(0);
+    }
+    ::time(&now);
+    return now;
+}
+
+ESP32_BLE_Presense::ESP32_BLE_Presense()
+:  esphome::PollingComponent(5000) {
+}
+
+void ESP32_BLE_Presense::update() {
+    if (!pBLEScan->isScanning()) {
+        ESP_LOGD("format_ble", "Start scanning...");
+        pBLEScan->start(0, nullptr, false);
+    }
+    ESP_LOGD("format_ble", "BLE scan heartbeat");
+}
+
+void ESP32_BLE_Presense::setup() {
+    PollingComponent::setup();
+
+    NimBLEDevice::init("");
+    NimBLEDevice::setPower(ESP_PWR_LVL_P9);
+    pBLEScan = NimBLEDevice::getScan();
+    pBLEScan->setAdvertisedDeviceCallbacks(new BleAdvertisedDeviceCallbacks(*this), true);
+    pBLEScan->setInterval(bleScanInterval);
+    pBLEScan->setWindow(bleScanWindow);
+    pBLEScan->setActiveScan(false);
+    pBLEScan->setMaxResults(0);
+    configTime(0, 0, "pool.ntp.org");
+    subscribe("format_ble_tracker/alive/+", &ESP32_BLE_Presense::on_alive_message);
+}
+
+void ESP32_BLE_Presense::reportDevice(const std::string& macAddress,
+                                    int rssi,
+                                    const std::string& manufacturerData) {
+
+    std::string mac_address = capitalizeString(macAddress);
+    unsigned long time = getTime();
+    if (std::find(macs.begin(), macs.end(), mac_address) != macs.end()) {
+        ESP_LOGD("format_ble", ("Sending for " + mac_address).c_str());
+        publish_json("format_ble_tracker/" + mac_address + "/" + name, [=](JsonObject root) {
+            root["rssi"] = rssi;
+            root["timestamp"] = time;
+        }, 1, true);
+        return;
+    }
+    std::string strManufacturerData = manufacturerData;
+    if (strManufacturerData != "") {
+        uint8_t cManufacturerData[100];
+        strManufacturerData.copy((char*)cManufacturerData, strManufacturerData.length(), 0);
+        std::string uuid_str = capitalizeString(NimBLEUUID(cManufacturerData+4, 16, true).toString().c_str());
+        if (std::find(uuids.begin(), uuids.end(), uuid_str) != uuids.end()) {
+            ESP_LOGD("format_ble", ("Sending for " + uuid_str).c_str());
+            publish_json("format_ble_tracker/" + uuid_str + "/" + name, [=](JsonObject root) {
+                root["rssi"] = rssi;
+                root["timestamp"] = time;
+            }, 1, true);
+            return;
+        }
+    }
+}
+
+
+void ESP32_BLE_Presense::on_alive_message(const std::string &topic, const std::string &payload) {
+    std::string uid = capitalizeString(topic.substr(topic.find_last_of("/") + 1));
+    if (payload == "True") {
+        if (uid.rfind(":") != std::string::npos) {
+            if (std::find(macs.begin(), macs.end(), uid) == macs.end()) {
+                ESP_LOGD("format_ble", ("Adding MAC  " + uid).c_str());
+                macs.push_back(uid);
+            } else {
+                ESP_LOGD("format_ble", ("Skipping duplicated MAC  " + uid).c_str());
+            }
+        } else if (uid.rfind("-") != std::string::npos) {
+            if (std::find(uuids.begin(), uuids.end(), uid) == uuids.end()) {
+                ESP_LOGD("format_ble", ("Adding UUID " + uid).c_str());
+                uuids.push_back(uid);
+            } else {
+                ESP_LOGD("format_ble", ("Skipping duplicated UUID  " + uid).c_str());
+            }
+        }
+        return;
+    } else {
+        ESP_LOGD("format_ble", ("Removing " + uid).c_str());
+        macs.erase(std::remove(macs.begin(), macs.end(), uid), macs.end());
+        uuids.erase(std::remove(uuids.begin(), uuids.end(), uid), uuids.end());
+    }
+}
+
+}

--- a/components/esp32_ble_presense/esp32_ble_presense.h
+++ b/components/esp32_ble_presense/esp32_ble_presense.h
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////
+// SPDX-License-Identifier: AGPL-3.0-only
+// (C) Copyright 2022-2024 - formatBCE
+
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/mqtt/custom_mqtt_device.h"
+
+namespace ESP32_BLE_Presense {
+
+class ESP32_BLE_Presense : public esphome::PollingComponent,
+                         public esphome::mqtt::CustomMQTTDevice {
+    std::string name;
+
+    std::vector<std::string> macs;
+    std::vector<std::string> uuids;
+
+public:
+
+    ESP32_BLE_Presense();
+    ~ESP32_BLE_Presense() = default;
+
+    void update() override;
+    void setup() override;
+
+    void set_area(std::string area) {
+        name = area;
+    }
+
+    ESP32_BLE_Presense(const ESP32_BLE_Presense&) = delete;
+    ESP32_BLE_Presense& operator=(const ESP32_BLE_Presense&) = delete;
+
+private:
+
+    friend class BleAdvertisedDeviceCallbacks;
+    void reportDevice(const std::string& mac_address,
+                      int rssi,
+                      const std::string& strManufacturerData);
+    void on_alive_message(const std::string &topic, const std::string &payload);
+};
+
+};

--- a/test/basic.yml
+++ b/test/basic.yml
@@ -1,0 +1,52 @@
+substitutions:
+  name: "project-template"
+
+########################################################################
+# Example platform
+
+esphome:
+  name: "${name}"
+  platformio_options:
+    build_flags:
+      - -Wall
+      - -Wextra
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+    version: recommended
+
+logger:
+
+api:
+
+ota:
+  platform: esphome
+
+wifi:
+  ap:
+    {}
+
+captive_portal:
+
+########################################################################
+# This section actually represents the test
+
+# Load ourselves from extrernal
+external_components:
+  - source: ../components
+    components: [ esp32_ble_presense ]
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+
+mqtt:
+  broker: mqtt.broker
+  username: mqtt_user
+  password: mqtt_pass
+  discovery: true
+
+esp32_ble_presense:
+  area: "Living Room"

--- a/test/requirements-dev.txt
+++ b/test/requirements-dev.txt
@@ -1,0 +1,1 @@
+esphome


### PR DESCRIPTION
I ported your code into an esphome component format.  This simplifies installation as follows (and post merge even simpler - see `external_components` below).

In this set of changes I've tried to preserve your code directly "as-is", while moving the dependencies inside the `.cpp` file to avoid conflicting library issues.

I have a future set of changes where I actually propose updates.

```yaml
# Would change to github://formatBCE/ESP32_BLE_presence@main post merge
external_components:
  source: github://whitty/ESP32_BLE_presense@dev/component

time:
  - platform: homeassistant
    id: homeassistant_time

esp32_ble_presense:
  area: "Living Room"

mqtt:
  broker: !secret mqtt_server
  username: !secret mqtt_user
  password: !secret mqtt_pass
  discovery: true
```

Additionally I have set up github actions to do a test build (this would have caught the error referenced in #1 and #2).

If you have a preferred configuration/device to test you should be able to add more `.yml` files to the `test/` directory.